### PR TITLE
chore: use golang:1.19 instead of ubuntu.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
-FROM ubuntu:22.04 as builder
+FROM golang:1.19 as builder
 
 ARG VERSION
 WORKDIR /service
+
 COPY ./api ./api
 COPY ./api_admin ./api_admin
 COPY ./cmd ./cmd
@@ -11,22 +12,9 @@ COPY ./config.toml ./
 COPY ./go.mod ./
 COPY ./go.sum ./
 
-RUN apt-get update
-RUN apt-get install -y wget build-essential ca-certificates
-RUN wget https://go.dev/dl/go1.19.linux-amd64.tar.gz
-
-# Configure Go
-ENV GOROOT /usr/local/go
-ENV GOPATH /go
-ENV PATH /usr/local/go/bin:/go/bin:$PATH
 ENV GOBIN /service/bin
 
-RUN tar -xvf go1.19.linux-amd64.tar.gz
-RUN mv go /usr/local
-
-RUN go mod download
 RUN go install -buildvcs=false -ldflags "-X main.build=${VERSION}" ./cmd/...
 RUN mv /service/bin/* /service/
-RUN rm -R /usr/local/go
+
 RUN rm -R /service/bin
-RUN rm ./go1.19.linux-amd64.tar.gz


### PR DESCRIPTION
Use golang: 1.19 instead of ubuntu.

Image size reduced from 2.91GB to 2.19 GB