### PR TITLE
chore: moving from Iden3SparseMerkleProof to Iden3SparseMerkleTreeProof

### DIFF
--- a/internal/core/domain/claim.go
+++ b/internal/core/domain/claim.go
@@ -146,8 +146,7 @@ func (c *Claim) GetVerifiableCredential() (verifiable.W3CCredential, error) {
 
 // GetCircuitIncProof TBD
 func (c *Claim) GetCircuitIncProof() (circuits.MTProof, error) {
-	// nolint: staticcheck
-	var proof verifiable.Iden3SparseMerkleProof
+	var proof verifiable.Iden3SparseMerkleTreeProof
 	err := c.MTPProof.AssignTo(&proof)
 	if err != nil {
 		return circuits.MTProof{}, err

--- a/internal/core/services/claims.go
+++ b/internal/core/services/claims.go
@@ -518,8 +518,8 @@ func (c *claim) UpdateClaimsMTPAndState(ctx context.Context, currentState *domai
 		if err != nil {
 			return err
 		}
-		mtpProof := verifiable.Iden3SparseMerkleProof{ // nolint: staticcheck
-			Type: verifiable.Iden3SparseMerkleProofType, // nolint: staticcheck
+		mtpProof := verifiable.Iden3SparseMerkleTreeProof{
+			Type: verifiable.Iden3SparseMerkleTreeProofType,
 			IssuerData: verifiable.IssuerData{
 				ID: did.String(),
 				State: verifiable.State{

--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -111,7 +111,7 @@ func (i *identity) SignClaimEntry(ctx context.Context, authClaim *domain.Claim, 
 
 	circuitSigner := signer.New(bbjSuite)
 
-	var issuerMTP verifiable.Iden3SparseMerkleProof // nolint: staticcheck
+	var issuerMTP verifiable.Iden3SparseMerkleTreeProof
 	err = authClaim.MTPProof.AssignTo(&issuerMTP)
 	if err != nil {
 		return nil, err
@@ -612,26 +612,26 @@ func (i *identity) createIdentity(ctx context.Context, tx db.Querier, DIDMethod 
 	return did, currentState.BigInt(), nil
 }
 
-func (i *identity) getAuthClaimMtpProof(ctx context.Context, claimsTree *merkletree.MerkleTree, currentState *merkletree.Hash, authClaim *core.Claim, did *core.DID) (verifiable.Iden3SparseMerkleProof, error) { // nolint: staticcheck
+func (i *identity) getAuthClaimMtpProof(ctx context.Context, claimsTree *merkletree.MerkleTree, currentState *merkletree.Hash, authClaim *core.Claim, did *core.DID) (verifiable.Iden3SparseMerkleTreeProof, error) {
 	index, err := authClaim.HIndex()
 	if err != nil {
-		return verifiable.Iden3SparseMerkleProof{}, err // nolint: staticcheck
+		return verifiable.Iden3SparseMerkleTreeProof{}, err
 	}
 
 	proof, _, err := claimsTree.GenerateProof(ctx, index, nil)
 	if err != nil {
-		return verifiable.Iden3SparseMerkleProof{}, err // nolint: staticcheck
+		return verifiable.Iden3SparseMerkleTreeProof{}, err
 	}
 
 	authClaimHex, err := authClaim.Hex()
 	if err != nil {
-		return verifiable.Iden3SparseMerkleProof{}, fmt.Errorf("auth claim core hex error: %w", err) // nolint: staticcheck
+		return verifiable.Iden3SparseMerkleTreeProof{}, fmt.Errorf("auth claim core hex error: %w", err)
 	}
 
 	stateHex := currentState.Hex()
 	cltHex := claimsTree.Root().Hex()
-	mtpProof := verifiable.Iden3SparseMerkleProof{ // nolint: staticcheck
-		Type: verifiable.Iden3SparseMerkleProofType, // nolint: staticcheck
+	mtpProof := verifiable.Iden3SparseMerkleTreeProof{
+		Type: verifiable.Iden3SparseMerkleTreeProofType,
 		IssuerData: verifiable.IssuerData{
 			ID:            did.String(),
 			AuthCoreClaim: authClaimHex,

--- a/internal/core/services/schema.go
+++ b/internal/core/services/schema.go
@@ -96,7 +96,7 @@ func (s *schema) FromClaimModelToW3CCredential(claim domain.Claim) (*verifiable.
 		proofs = append(proofs, signatureProof)
 	}
 
-	var mtpProof *verifiable.Iden3SparseMerkleProof // nolint: staticcheck
+	var mtpProof *verifiable.Iden3SparseMerkleTreeProof
 
 	if claim.MTPProof.Status != pgtype.Null {
 		err = claim.MTPProof.AssignTo(&mtpProof)

--- a/internal/db/schema/migrations/20230309164801_update_claims_mtp_proof_column.sql
+++ b/internal/db/schema/migrations/20230309164801_update_claims_mtp_proof_column.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE claims SET mtp_proof = jsonb_set(mtp_proof, '{type}', '"Iden3SparseMerkleTreeProof"');
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+UPDATE claims SET mtp_proof = jsonb_set(mtp_proof, '{type}', '"Iden3SparseMerkleProof"');
+-- +goose StatementEnd


### PR DESCRIPTION
Iden3SparseMerkleProof was deprecated and updated with Iden3SparseMerkleTreeProof

Libraries updated:

https://github.com/iden3/go-merkletree-sql/releases/tag/v2.0.2
https://github.com/iden3/go-iden3-crypto/releases/tag/v0.0.14
https://github.com/iden3/go-iden3-core/releases/tag/v1.0.1
https://github.com/iden3/go-schema-processor/releases/tag/v1.1.2