### PR TITLE
Code Owners proposal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,8 @@
 /internal           @0xPolygonID/backend
 /pkg                @0xPolygonID/backend
 
+/ui                 @0xPolygonID/frontend
+
 ./.github           @martinsaporiti
 
-# No prefixed code owners
-/ui
+

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,15 @@
-# Global code owners
-*   @martinsaporiti @javip97 @x1m3
+# Any file in root, folders excluded
+/*                  @0xPolygonID/backend
 
-# UI code owners
-/ui @adrifdez @cneuro @amonsosanz @elias-garcia
+# Other folders
+/api                @0xPolygonID/backend
+/api-ui             @0xPolygonID/backend
+/cmd                @0xPolygonID/backend
+/infrastructure     @0xPolygonID/backend
+/internal           @0xPolygonID/backend
+/pkg                @0xPolygonID/backend
+
+./.github           @martinsaporiti
+
+# No prefixed code owners
+/ui


### PR DESCRIPTION
Change the code owners file to better fit  backend and frontend teams workflow.

Backend team members will be automatically placed as code reviewers for any PR that affects backend folders and root files.

Frontend team members will be code owners of /ui folder