### PR TITLE
chore: renaming credential attributes for credential subject

### DIFF
--- a/api_ui/api.yaml
+++ b/api_ui/api.yaml
@@ -967,7 +967,7 @@ components:
         - schemaHash
         - schemaType
         - revNonce
-        - attributes
+        - credentialSubject
         - revoked
       properties:
         id:
@@ -1006,7 +1006,7 @@ components:
           type: integer
           format: uint64
           example: 2136005230
-        attributes:
+        credentialSubject:
           type: object
           x-omitempty: false
           example:

--- a/api_ui/api.yaml
+++ b/api_ui/api.yaml
@@ -512,7 +512,7 @@ paths:
   # Links
   /v1/credentials/links:
     get:
-      summary: Returns the list of links to credentials
+      summary: Get Links
       operationId: GetLinks
       security:
         - basicAuth: [ ]

--- a/internal/api_admin/api.gen.go
+++ b/internal/api_admin/api.gen.go
@@ -418,7 +418,7 @@ type ServerInterface interface {
 	// Create Credential
 	// (POST /v1/credentials)
 	CreateCredential(w http.ResponseWriter, r *http.Request)
-	// Returns the list of links to credentials
+	// Get Links
 	// (GET /v1/credentials/links)
 	GetLinks(w http.ResponseWriter, r *http.Request, params GetLinksParams)
 	// Create Link
@@ -2598,7 +2598,7 @@ type StrictServerInterface interface {
 	// Create Credential
 	// (POST /v1/credentials)
 	CreateCredential(ctx context.Context, request CreateCredentialRequestObject) (CreateCredentialResponseObject, error)
-	// Returns the list of links to credentials
+	// Get Links
 	// (GET /v1/credentials/links)
 	GetLinks(ctx context.Context, request GetLinksRequestObject) (GetLinksResponseObject, error)
 	// Create Link

--- a/internal/api_admin/api.gen.go
+++ b/internal/api_admin/api.gen.go
@@ -88,16 +88,16 @@ type CreateLinkRequest struct {
 
 // Credential defines model for Credential.
 type Credential struct {
-	Attributes map[string]interface{} `json:"attributes"`
-	CreatedAt  time.Time              `json:"createdAt"`
-	Expired    bool                   `json:"expired"`
-	ExpiresAt  *time.Time             `json:"expiresAt,omitempty"`
-	Id         uuid.UUID              `json:"id"`
-	ProofTypes []string               `json:"proofTypes"`
-	RevNonce   uint64                 `json:"revNonce"`
-	Revoked    bool                   `json:"revoked"`
-	SchemaHash string                 `json:"schemaHash"`
-	SchemaType string                 `json:"schemaType"`
+	CreatedAt         time.Time              `json:"createdAt"`
+	CredentialSubject map[string]interface{} `json:"credentialSubject"`
+	Expired           bool                   `json:"expired"`
+	ExpiresAt         *time.Time             `json:"expiresAt,omitempty"`
+	Id                uuid.UUID              `json:"id"`
+	ProofTypes        []string               `json:"proofTypes"`
+	RevNonce          uint64                 `json:"revNonce"`
+	Revoked           bool                   `json:"revoked"`
+	SchemaHash        string                 `json:"schemaHash"`
+	SchemaType        string                 `json:"schemaType"`
 }
 
 // CredentialLinkQrCodeResponse defines model for CredentialLinkQrCodeResponse.

--- a/internal/api_admin/responses.go
+++ b/internal/api_admin/responses.go
@@ -44,16 +44,16 @@ func credentialResponse(w3c *verifiable.W3CCredential, credential *domain.Claim)
 	proofs := getProofs(w3c, credential)
 
 	return Credential{
-		Attributes: w3c.CredentialSubject,
-		CreatedAt:  *w3c.IssuanceDate,
-		Expired:    expired,
-		ExpiresAt:  w3c.Expiration,
-		Id:         credential.ID,
-		ProofTypes: proofs,
-		RevNonce:   uint64(credential.RevNonce),
-		Revoked:    credential.Revoked,
-		SchemaHash: credential.SchemaHash,
-		SchemaType: credential.SchemaType,
+		CredentialSubject: w3c.CredentialSubject,
+		CreatedAt:         *w3c.IssuanceDate,
+		Expired:           expired,
+		ExpiresAt:         w3c.Expiration,
+		Id:                credential.ID,
+		ProofTypes:        proofs,
+		RevNonce:          uint64(credential.RevNonce),
+		Revoked:           credential.Revoked,
+		SchemaHash:        credential.SchemaHash,
+		SchemaType:        credential.SchemaType,
 	}
 }
 

--- a/internal/api_admin/server_test.go
+++ b/internal/api_admin/server_test.go
@@ -1247,7 +1247,7 @@ func TestServer_GetCredential(t *testing.T) {
 			},
 			expected: expected{
 				response: Credential{
-					Attributes: map[string]interface{}{
+					CredentialSubject: map[string]interface{}{
 						"id":           "did:polygonid:polygon:mumbai:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ",
 						"birthday":     19960424,
 						"documentType": 2,
@@ -1274,7 +1274,7 @@ func TestServer_GetCredential(t *testing.T) {
 			},
 			expected: expected{
 				response: Credential{
-					Attributes: map[string]interface{}{
+					CredentialSubject: map[string]interface{}{
 						"id":           "did:polygonid:polygon:mumbai:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ",
 						"birthday":     19960424,
 						"documentType": 2,
@@ -1301,7 +1301,7 @@ func TestServer_GetCredential(t *testing.T) {
 			},
 			expected: expected{
 				response: Credential{
-					Attributes: map[string]interface{}{
+					CredentialSubject: map[string]interface{}{
 						"id":           "did:polygonid:polygon:mumbai:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ",
 						"birthday":     19960424,
 						"documentType": 2,
@@ -1694,7 +1694,7 @@ func TestServer_GetConnection(t *testing.T) {
 					UserID:    usrDID.String(),
 					Credentials: []Credential{
 						{
-							Attributes: map[string]interface{}{
+							CredentialSubject: map[string]interface{}{
 								"id":           "did:polygonid:polygon:mumbai:2qE1BZ7gcmEoP2KppvFPCZqyzyb5tK9T6Gec5HFANQ",
 								"birthday":     19960424,
 								"documentType": 2,
@@ -2219,8 +2219,8 @@ func validateCredential(t *testing.T, tc Credential, response Credential) {
 	}
 	assert.Equal(t, tc.Expired, response.Expired)
 	var respAttributes, tcCredentialSubject credentialKYCSubject
-	assert.NoError(t, mapstructure.Decode(tc.Attributes, &tcCredentialSubject))
-	assert.NoError(t, mapstructure.Decode(response.Attributes, &respAttributes))
+	assert.NoError(t, mapstructure.Decode(tc.CredentialSubject, &tcCredentialSubject))
+	assert.NoError(t, mapstructure.Decode(response.CredentialSubject, &respAttributes))
 	assert.EqualValues(t, respAttributes, tcCredentialSubject)
 	assert.EqualValues(t, tc.ProofTypes, response.ProofTypes)
 }

--- a/internal/core/services/tests/link_test.go
+++ b/internal/core/services/tests/link_test.go
@@ -3,6 +3,7 @@ package services_tests
 import (
 	"context"
 	"errors"
+	"github.com/polygonid/sh-id-platform/pkg/pubsub"
 	"testing"
 	"time"
 
@@ -31,7 +32,7 @@ func Test_link_issueClaim(t *testing.T) {
 	mtService := services.NewIdentityMerkleTrees(mtRepo)
 	rhsp := reverse_hash.NewRhsPublisher(nil, false)
 	connectionsRepository := repositories.NewConnections()
-	identityService := services.NewIdentity(keyStore, identityRepo, mtRepo, identityStateRepo, mtService, claimsRepo, revocationRepository, connectionsRepository, storage, rhsp, nil, nil)
+	identityService := services.NewIdentity(keyStore, identityRepo, mtRepo, identityStateRepo, mtService, claimsRepo, revocationRepository, connectionsRepository, storage, rhsp, nil, nil, pubsub.NewMock())
 	schemaLoader := loader.HTTPFactory
 	sessionRepository := repositories.NewSessionCached(cachex)
 	schemaService := services.NewSchemaAdmin(schemaRepository, schemaLoader)
@@ -47,7 +48,7 @@ func Test_link_issueClaim(t *testing.T) {
 		schemaLoader,
 		storage,
 		claimsConf,
-	)
+		pubsub.NewMock())
 
 	identity, err := identityService.Create(ctx, method, blockchain, network, "http://localhost:3001")
 	assert.NoError(t, err)

--- a/internal/core/services/tests/link_test.go
+++ b/internal/core/services/tests/link_test.go
@@ -3,7 +3,6 @@ package services_tests
 import (
 	"context"
 	"errors"
-	"github.com/polygonid/sh-id-platform/pkg/pubsub"
 	"testing"
 	"time"
 
@@ -18,6 +17,7 @@ import (
 	"github.com/polygonid/sh-id-platform/internal/loader"
 	"github.com/polygonid/sh-id-platform/internal/repositories"
 	linkState "github.com/polygonid/sh-id-platform/pkg/link"
+	"github.com/polygonid/sh-id-platform/pkg/pubsub"
 	"github.com/polygonid/sh-id-platform/pkg/reverse_hash"
 )
 


### PR DESCRIPTION
Affected endpoints:
* Get Credential
* Get Connections
* Get Connection

rename:
 `Returns the list of links to credentials` for `Get Links` 