### PR TITLE
feat: avoid sending notifications when updating connections

### DIFF
--- a/internal/core/services/identity.go
+++ b/internal/core/services/identity.go
@@ -411,9 +411,11 @@ func (i *identity) Authenticate(ctx context.Context, message string, sessionID u
 		return nil, err
 	}
 
-	err = i.pubsub.Publish(ctx, pubsub.EventCreateConnection, pubsub.CreateConnectionEvent{ConnectionID: connID.String(), IssuerID: issuerDID.String()})
-	if err != nil {
-		log.Error(ctx, "sending connection notification", "err", err.Error(), "connection", connID)
+	if connID == conn.ID { // a connection has been created so previously created credentials have to be sent
+		err = i.pubsub.Publish(ctx, pubsub.EventCreateConnection, pubsub.CreateConnectionEvent{ConnectionID: connID.String(), IssuerID: issuerDID.String()})
+		if err != nil {
+			log.Error(ctx, "sending connection notification", "err", err.Error(), "connection", connID)
+		}
 	}
 
 	return arm, nil

--- a/internal/repositories/connections.go
+++ b/internal/repositories/connections.go
@@ -45,10 +45,9 @@ func NewConnections() ports.ConnectionsRepository {
 func (c *connections) Save(ctx context.Context, conn db.Querier, connection *domain.Connection) (uuid.UUID, error) {
 	var id uuid.UUID
 	sql := `INSERT INTO connections (id,issuer_id, user_id, issuer_doc, user_doc,created_at,modified_at)
-			VALUES($1, $2, $3, $4,$5,$6,$7) ON CONFLICT (issuer_id, user_id) DO
-			UPDATE SET issuer_id=$2, user_id=$3, issuer_doc=$4, user_doc=$5,
-			           modified_at = $7
-	RETURNING id`
+			VALUES($1, $2, $3, $4,$5,$6,$7) ON CONFLICT ON CONSTRAINT connections_issuer_user_key DO
+			UPDATE SET issuer_id=$2, user_id=$3, issuer_doc=$4, user_doc=$5, modified_at = $7
+			RETURNING id`
 	err := conn.QueryRow(ctx, sql, connection.ID, connection.IssuerDID.String(), connection.UserDID.String(), connection.IssuerDoc, connection.UserDoc, connection.CreatedAt, connection.ModifiedAt).Scan(&id)
 
 	return id, err

--- a/internal/repositories/tests/connections_test.go
+++ b/internal/repositories/tests/connections_test.go
@@ -23,13 +23,24 @@ func TestSave(t *testing.T) {
 	userDID, err := core.ParseDID("did:polygonid:polygon:mumbai:2qH7XAwYQzCp9VfhpNgeLtK2iCehDDrfMWUCEg5ig5")
 	require.NoError(t, err)
 
-	// when and then
-	t.Run("should save the connection", func(t *testing.T) {
-		_, err := connectionsRepo.Save(context.Background(), storage.Pgx, &domain.Connection{
-			UserDID:   *userDID,
-			IssuerDID: *issuerDID,
-		})
+	conn := &domain.Connection{
+		ID:        uuid.New(),
+		UserDID:   *userDID,
+		IssuerDID: *issuerDID,
+	}
+
+	conn2 := &domain.Connection{
+		ID:        uuid.New(),
+		UserDID:   *userDID,
+		IssuerDID: *issuerDID,
+	}
+	t.Run("should save or update the connection", func(t *testing.T) {
+		connID, err := connectionsRepo.Save(context.Background(), storage.Pgx, conn)
 		assert.NoError(t, err)
+		assert.Equal(t, conn.ID, connID)
+		connID2, err := connectionsRepo.Save(context.Background(), storage.Pgx, conn2) // updating connection
+		assert.NoError(t, err)
+		assert.NotEqual(t, conn2.ID, connID2) // checking that the connections is being updated and no ID is modified on conflict
 	})
 }
 

--- a/internal/repositories/tests/connections_test.go
+++ b/internal/repositories/tests/connections_test.go
@@ -18,9 +18,9 @@ import (
 
 func TestSave(t *testing.T) {
 	connectionsRepo := repositories.NewConnections()
-	issuerDID, err := core.ParseDID("did:iden3:polygon:mumbai:wyFiV4w71QgWPn6bYLsZoysFay66gKtVa9kfu6yMZ")
+	issuerDID, err := core.ParseDID("did:polygonid:polygon:mumbai:2qCp9Tx4x5hzchym1dZXtBpwRQsH7HXe7GcbvskoRn")
 	require.NoError(t, err)
-	userDID, err := core.ParseDID("did:polygonid:polygon:mumbai:2qH7XAwYQzCp9VfhpNgeLtK2iCehDDrfMWUCEg5ig5")
+	userDID, err := core.ParseDID("did:polygonid:polygon:mumbai:2qHgCmGW1wDH5ShTH94SssR4eN8XW4xyHLfop2Qoqm")
 	require.NoError(t, err)
 
 	conn := &domain.Connection{
@@ -37,7 +37,7 @@ func TestSave(t *testing.T) {
 	t.Run("should save or update the connection", func(t *testing.T) {
 		connID, err := connectionsRepo.Save(context.Background(), storage.Pgx, conn)
 		assert.NoError(t, err)
-		assert.Equal(t, conn.ID, connID)
+		assert.Equal(t, conn.ID.String(), connID.String())
 		connID2, err := connectionsRepo.Save(context.Background(), storage.Pgx, conn2) // updating connection
 		assert.NoError(t, err)
 		assert.NotEqual(t, conn2.ID, connID2) // checking that the connections is being updated and no ID is modified on conflict


### PR DESCRIPTION
* Send push notifications only when a connection is created, not when updated
* Ensures that push notification token is updated when the connection is updated