### PR TITLE
chore: improving create credential errors

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -127,6 +127,15 @@ func (s *Server) CreateClaim(ctx context.Context, request CreateClaimRequestObje
 		if errors.Is(err, services.ErrMalformedURL) {
 			return CreateClaim400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
 		}
+		if errors.Is(err, services.ErrParseClaim) {
+			return CreateClaim400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
+		if errors.Is(err, services.ErrInvalidCredentialSubject) {
+			return CreateClaim400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
+		if errors.Is(err, services.ErrLoadingSchema) {
+			return CreateClaim400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
 		return CreateClaim500JSONResponse{N500JSONResponse{Message: err.Error()}}, nil
 	}
 	return CreateClaim201JSONResponse{Id: resp.ID.String()}, nil

--- a/internal/api_ui/server.go
+++ b/internal/api_ui/server.go
@@ -322,6 +322,15 @@ func (s *Server) CreateCredential(ctx context.Context, request CreateCredentialR
 		if errors.Is(err, services.ErrLoadingSchema) {
 			return CreateCredential422JSONResponse{N422JSONResponse{Message: err.Error()}}, nil
 		}
+		if errors.Is(err, services.ErrParseClaim) {
+			return CreateCredential400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
+		if errors.Is(err, services.ErrInvalidCredentialSubject) {
+			return CreateCredential400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
+		if errors.Is(err, services.ErrLoadingSchema) {
+			return CreateCredential400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
+		}
 		if errors.Is(err, services.ErrMalformedURL) {
 			return CreateCredential400JSONResponse{N400JSONResponse{Message: err.Error()}}, nil
 		}

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	core "github.com/iden3/go-iden3-core"
@@ -13,6 +14,12 @@ import (
 
 	"github.com/polygonid/sh-id-platform/internal/core/domain"
 	"github.com/polygonid/sh-id-platform/internal/loader"
+)
+
+var (
+	ErrLoadSchema   = errors.New("cannot load schema")          // ErrProcessSchema Cannot process schema
+	ErrValidateData = errors.New("error validating claim data") // ErrValidateData Cannot process schema
+	ErrParseClaim   = errors.New("error parsing claim")         // ErrParseClaim Cannot process schema
 )
 
 // LoadSchema loads schema from url
@@ -93,7 +100,7 @@ func Process(ctx context.Context, ld loader.Loader, credentialType string, crede
 
 	schema, _, err := pr.Load(ctx)
 	if err != nil {
-		return nil, err
+		return nil, ErrLoadSchema
 	}
 
 	jsonCredential, err := json.Marshal(credential)
@@ -103,12 +110,12 @@ func Process(ctx context.Context, ld loader.Loader, credentialType string, crede
 
 	err = pr.ValidateData(jsonCredential, schema)
 	if err != nil {
-		return nil, err
+		return nil, ErrValidateData
 	}
 
 	claim, err := pr.ParseClaim(ctx, credential, credentialType, schema, options)
 	if err != nil {
-		return nil, err
+		return nil, ErrParseClaim
 	}
 	return claim, nil
 }

--- a/pkg/schema/schema.go
+++ b/pkg/schema/schema.go
@@ -17,7 +17,7 @@ import (
 )
 
 var (
-	ErrLoadSchema   = errors.New("cannot load schema")          // ErrProcessSchema Cannot process schema
+	ErrLoadSchema   = errors.New("cannot load schema")          // ErrLoadSchema Cannot process schema
 	ErrValidateData = errors.New("error validating claim data") // ErrValidateData Cannot process schema
 	ErrParseClaim   = errors.New("error parsing claim")         // ErrParseClaim Cannot process schema
 )


### PR DESCRIPTION
example of improvement:

Creating a credential where the credentialSubject does not match the given schema:

**previous error:**

```
{
    "message": "cannot process schema"
}
```

**current error**

```
{
    "message": "credential subject does not match the provided schema"
}
```
