### PR TITLE
fix: returning an error when trying to create qr code for invalid link

### DIFF
--- a/internal/api_ui/server.go
+++ b/internal/api_ui/server.go
@@ -540,8 +540,11 @@ func (s *Server) DeleteLink(ctx context.Context, request DeleteLinkRequestObject
 func (s *Server) CreateLinkQrCode(ctx context.Context, request CreateLinkQrCodeRequestObject) (CreateLinkQrCodeResponseObject, error) {
 	createLinkQrCodeResponse, err := s.linkService.CreateQRCode(ctx, s.cfg.APIUI.IssuerDID, request.Id, s.cfg.APIUI.ServerURL)
 	if err != nil {
-		if errors.Is(services.ErrLinkNotFound, err) {
+		if errors.Is(err, services.ErrLinkNotFound) {
 			return CreateLinkQrCode404JSONResponse{N404JSONResponse{Message: "error: link not found"}}, nil
+		}
+		if errors.Is(err, services.ErrLinkAlreadyExpired) || errors.Is(err, services.ErrLinkMaxExceeded) || errors.Is(err, services.ErrLinkInactive) {
+			return CreateLinkQrCode404JSONResponse{N404JSONResponse{Message: "error: " + err.Error()}}, nil
 		}
 		log.Error(ctx, "Unexpected error while creating qr code", "err", err)
 		return CreateLinkQrCode500JSONResponse{N500JSONResponse{"Unexpected error while creating qr code"}}, nil

--- a/internal/core/services/link.go
+++ b/internal/core/services/link.go
@@ -323,12 +323,12 @@ func (ls *Link) validate(ctx context.Context, link *domain.Link) error {
 	}
 
 	if link.MaxIssuance != nil && *link.MaxIssuance <= link.IssuedClaims {
-		log.Debug(ctx, "cannot dispatch more claims for this link")
+		log.Debug(ctx, "cannot dispatch more credentials for this link")
 		return ErrLinkMaxExceeded
 	}
 
 	if !link.Active {
-		log.Debug(ctx, "cannot dispatch claim for inactive link")
+		log.Debug(ctx, "cannot dispatch credentials for inactive link")
 		return ErrLinkInactive
 	}
 


### PR DESCRIPTION
This PR contains the validation of a link in order to generate a qr code. Invalid links will cause a 404 error

Definition of invalid link:
1. Link is not active
2. Link has reached the maximum amount 
3. Link is expired