### PR TITLE
fix: publish state

### DIFF
--- a/internal/repositories/claims.go
+++ b/internal/repositories/claims.go
@@ -795,7 +795,8 @@ func (c *claims) GetAuthClaimsForPublishing(ctx context.Context, conn db.Querier
 		identity_states.status,
        	credential_status,
        	core_claim,
-       	revoked
+       	revoked,
+		mtp
 	FROM claims
 	LEFT JOIN identity_states  ON claims.identity_state = identity_states.state
 	LEFT JOIN revocation  ON claims.rev_nonce = revocation.nonce AND claims.issuer = revocation.identifier


### PR DESCRIPTION
This PR solves the error for publish state | retry publish state.
> "number of field descriptions must equal number of destinations, got 19 and 20"