### PR TITLE
fix: wrong verifiable credential id in api-ui

### DIFF
--- a/internal/core/services/claims.go
+++ b/internal/core/services/claims.go
@@ -573,7 +573,7 @@ func (c *claim) newVerifiableCredential(claimReq *ports.CreateClaimRequest, vcID
 
 	issuanceDate := time.Now()
 	return verifiable.W3CCredential{
-		ID:                fmt.Sprintf("%s/v1/%s/claims/%s", strings.TrimSuffix(c.cfg.Host, "/"), claimReq.DID.String(), vcID),
+		ID:                c.buildCredentialID(*claimReq.DID, vcID, claimReq.SingleIssuer),
 		Context:           credentialCtx,
 		Type:              credentialType,
 		Expiration:        claimReq.Expiration,
@@ -606,6 +606,14 @@ func (c *claim) getRevocationSource(issuerDID string, nonce uint64, singleIssuer
 		Type:            verifiable.SparseMerkleTreeProof,
 		RevocationNonce: nonce,
 	}
+}
+
+func (c *claim) buildCredentialID(issuerDID core.DID, credID uuid.UUID, singleIssuer bool) string {
+	if singleIssuer {
+		return fmt.Sprintf("%s/v1/credentials/%s", strings.TrimSuffix(c.cfg.Host, "/"), credID.String())
+	}
+
+	return fmt.Sprintf("%s/v1/%s/claims/%s", strings.TrimSuffix(c.cfg.Host, "/"), issuerDID.String(), credID.String())
 }
 
 func buildRevocationURL(host, issuerDID string, nonce uint64, singleIssuer bool) string {


### PR DESCRIPTION
previous format:  {host}/v1/{issuerDID}/claims/{claimID} 
expected format: {host}/v1/credentials/{credentialID}